### PR TITLE
Korjaus 3.1: "Valitsimia voi käyttää myös lasten valintaa" (rivi 703)

### DIFF
--- a/index.html
+++ b/index.html
@@ -700,7 +700,7 @@ body {
 }
 </pre>
 
-    <p>Valitsimia voi käyttää myös lasten valintaa, esimerkiksi seuraavassa valitaan ensimmäisen valitsimen joukosta toisen valitsimen tyyppinen lapsi.</p>
+    <p>Valitsimia voi käyttää myös <a href="http://en.wikipedia.org/wiki/Tree_(data_structure)" target="_blank">lasten</a> valintaan, esimerkiksi seuraavassa valitaan ensimmäisen valitsimen joukosta toisen valitsimen tyyppinen lapsi.</p>
 
 <pre class="sh_css">
 <em>valitsin</em> &gt; <em>valitsin2</em> {


### PR DESCRIPTION
Valitsimia voi käyttää myös lasten valintaa, esimerkiksi seuraavassa valitaan ensimmäisen valitsimen joukosta toisen valitsimen tyyppinen lapsi. 


Tässä ilmeisesti tarkoitetaan, että "lasten valintaaN". 

Ja koska kurssimateriaalissa aletaan ensimmäistä kertaa ja ilman ennakkovaroitusta puhumaan "lapsista", niin selventävä linkki olisi varmaankin paikallaan.

Kthxbye.
