### PR TITLE
Void elements in HTML5

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,9 @@
 
 	<p>HTML on kieli web-sivustojen luomiseen. HTML ei ole ohjelmointikieli, vaan kuvauskieli, jonka avulla kuvataan sekä web-sivun rakenne että sivun sisältämä teksti. HTML-sivujen rakenne määritellään HTML-kielessä määritellyillä elementeillä, ja yksittäinen HTML-dokumentti koostuu sisäkkäin ja peräkkäin olevista elementeistä.</p>
 
-	<p>Sivujen rakenteen määrittelevät elementit erotellaan pienempi kuin (&lt;) ja suurempi kuin (&gt;) -merkeillä. Elementti avataan elementin nimen sisältävällä pienempi kuin -merkillä alkavalla ja suurempi kuin -merkkiin loppuvalla merkkijonolla, esim. <code>&lt;html&gt;</code>, ja suljetaan merkkijonolla jossa elementin pienempi kuin -merkin jälkeen on vinoviiva, esim <code>&lt;/html&gt;</code>. Yksittäisen elementin sisälle voi laittaa muita elementtejä, ja elementti tulee sulkea aina lopuksi. Jos elementti ei sisällä muita elementtejä tai tekstiä, voi sen avata ja sulkea yksittäisellä komennolla, esim. <code>&lt;br/&gt;</code>.</p>
+	<p>Sivujen rakenteen määrittelevät elementit erotellaan pienempi kuin (&lt;) ja suurempi kuin (&gt;) -merkeillä. Elementti avataan elementin nimen sisältävällä pienempi kuin -merkillä alkavalla ja suurempi kuin -merkkiin loppuvalla merkkijonolla, esim. <code>&lt;html&gt;</code>, ja suljetaan merkkijonolla jossa elementin pienempi kuin -merkin jälkeen on vinoviiva, esim <code>&lt;/html&gt;</code>. Yksittäisen elementin sisälle voi laittaa muita elementtejä.</p>
+
+  <p>Suurin osa elementeistä tulee sulkea lopuksi. Osa HTML5:n elementeistä &ndash; esimerkiksi <code>&lt;br&gt;</code> &ndash; on kuitenkin ns. tyhjiä ("void"), eikä niille kirjoiteta erillistä lopetusta. Halutessaan tyhjät elementit voi lopettaa X(HT)ML-tyyliseen /-merkkiin, esimerkiksi seuraavasti: <code>&lt;br /&gt;</code>.</p>
 
 
 	<h3>HTML-dokumentin runko</h3>


### PR DESCRIPTION
Self closing tags are X(HT)ML -- still allowed in HTML5 but not the primary way. Void elements just have no closing tags since there is no possibility of them containing anything.
