### PR TITLE
Xmlhttprequest

### DIFF
--- a/index.html
+++ b/index.html
@@ -3676,7 +3676,7 @@ req.onreadystatechange = function() {
 }
 
 req.open("GET", "data.json", true);
-req.send("");
+req.send();
 </textarea></p>
       <p><input type="button" onclick="evalElementContent('js-xmlhttpreq-haku')" value="Suorita koodi!"></input></p>
     </div>
@@ -3769,7 +3769,7 @@ document.body.appendChild(script);
 var req = new XMLHttpRequest();
 var parametrit = "nimi=mikke&ika=17";
 req.open("GET", "dataprocessor.html?" + parametrit, true);
-req.send("");
+req.send();
 </pre>
 
     <p>GET-pyyntö on hieman huono siinä mielessä, että lähetettävä data näkyy kaikkialle. Esimerkiksi jos pyyntö kulkee useamman reitittimen läpi ennen pääsyä palvelimelle, jokainen reititin näkee parametrit. Toinen vaihtoehto on POST-pyyntö, jossa data lähetetään osana pyynnön runkoa. Tällöin pyynnölle tulee myös määritellä lähetettävän datan muoto. Allaolevassa esimerkissä sanomme datan olevan lomakkeelta.</p>

--- a/index.html
+++ b/index.html
@@ -3780,8 +3780,6 @@ var data = "nimi=mikke&ika=17";
 req.open("POST", "dataprocessor.html", true);
 
 req.setRequestHeader("Content-Type","application/x-www-form-urlencoded");
-req.setRequestHeader("Content-Length", data.length);
-req.setRequestHeader("Connection", "close");
 
 req.send(data);
 </pre>
@@ -3796,8 +3794,6 @@ var req = new XMLHttpRequest();
 req.open("POST", "jsonprocessor.html", true);
 
 req.setRequestHeader("Content-Type","application/json");
-req.setRequestHeader("Content-Length", data.length);
-req.setRequestHeader("Connection", "close");
 
 req.send(data);
 </pre>

--- a/index.html
+++ b/index.html
@@ -3665,7 +3665,7 @@ req.send();
 
     <p>Ylläolevassa esimerkiksi vastaus näytetään <code>console.log</code>-komennon avulla. Käytännössä JSON-dataa sisältävän vastauksen voisi muuttaa <code>JSON.parse</code>-funktiolla olioksi.</p>
 
-    <p>Tärkeä osa liittyy pyynnön avaamiseen. Komento <code>req.open("GET", "data.json", true);</code> avaa GET-tyyppisen HTTP-yhteyden <em>nykyiseen sivustoon</em> liittyvään osoitteeseen <code>data.json</code>. Koska viimeinen parametri on <code>true</code>, on pyyntötyyppi asynkroninen, eikä selain jää odottamaan vastausta. Vastaukseen reagoidaan kun vastaus saapuu.</p>
+    <p>Tärkeä osa liittyy pyynnön avaamiseen. Komento <code>req.open("GET", "data.json", true);</code> avaa GET-tyyppisen HTTP-yhteyden <em>nykyiseen sivustoon</em> liittyvään osoitteeseen <code>data.json</code>. Koska viimeinen parametri on <code>true</code>, on pyyntötyyppi asynkroninen, eikä selain jää odottamaan vastausta. Vastaukseen reagoidaan kun vastaus saapuu. Asynkronisuuden määrittävä boolenia ei kuitenkaan vaadita ja pyyntö on oletusarvoisesti asynkroninen jollei toisin määritetä. Täten parametri täytyy erikseen asettaa vain jos sen arvoksi haluaa <code>false</code>.</p>
 
 
     <div class="test-js">
@@ -3675,7 +3675,7 @@ req.onreadystatechange = function() {
     console.log(req.readyState + ", " + req.status + ", " + req.responseText);
 }
 
-req.open("GET", "data.json", true);
+req.open("GET", "data.json");
 req.send();
 </textarea></p>
       <p><input type="button" onclick="evalElementContent('js-xmlhttpreq-haku')" value="Suorita koodi!"></input></p>
@@ -3768,7 +3768,7 @@ document.body.appendChild(script);
 // pyyntöolion luonti
 var req = new XMLHttpRequest();
 var parametrit = "nimi=mikke&ika=17";
-req.open("GET", "dataprocessor.html?" + parametrit, true);
+req.open("GET", "dataprocessor.html?" + parametrit);
 req.send();
 </pre>
 
@@ -3777,7 +3777,7 @@ req.send();
 <pre class="sh_javascript_dom">
 var req = new XMLHttpRequest();
 var data = "nimi=mikke&ika=17";
-req.open("POST", "dataprocessor.html", true);
+req.open("POST", "dataprocessor.html");
 
 req.setRequestHeader("Content-Type","application/x-www-form-urlencoded");
 
@@ -3791,7 +3791,7 @@ var mikke = {nimi: "Michael", ika: 17};
 var data = JSON.stringify(mikke);
 
 var req = new XMLHttpRequest();
-req.open("POST", "jsonprocessor.html", true);
+req.open("POST", "jsonprocessor.html");
 
 req.setRequestHeader("Content-Type","application/json");
 

--- a/index.html
+++ b/index.html
@@ -3641,8 +3641,8 @@ var req = new XMLHttpRequest();
 
 // mitä tehdään kun saadaan vastaus (vastauksia voi olla useita)
 req.onreadystatechange = function() {
-    // jos tila ei ole 4 (valmis), ei käsitellä
-    if (req.readyState !== 4) {
+    // jos tila ei ole valmis, ei käsitellä
+    if (req.readyState !== this.DONE) {
         console.log("state " + req.readyState);
         return false;
     }
@@ -3658,10 +3658,10 @@ req.onreadystatechange = function() {
 }
 
 req.open("GET", "data.json", true);
-req.send("");
+req.send();
 </pre>
 
-    <p>Tutkitaan yllä olevaa koodia hieman tarkemmin. Palvelin voi palauttaa XMLHttpRequest-pyyntöön useamman vastauksen. Attribuutti <code>readyState</code> sisältää arvon väliltä [0, 4], missä 4 tarkoittaa pyynnön olevan valmis. Jos attribuutin <code>readyState</code> arvo ei ole neljä, odotamme lopullista vastausta. Attribuutti <code>status</code> kertoo HTTP-pyynnön statuskoodin. Statuskoodi 200 kertoo pyynnön onnistuneen. Lisää tietoa statuskoodeista löytyy esimerkiksi googlella ja <a href="http://httpstatuscats.com/" target="_blank">täältä</a>.</p>
+    <p>Tutkitaan yllä olevaa koodia hieman tarkemmin. Palvelin voi palauttaa XMLHttpRequest-pyyntöön useamman vastauksen. Attribuutti <code>readyState</code> sisältää arvon väliltä [0, 4], missä 4 tarkoittaa pyynnön olevan valmis. Numeroarvoja vastaavat vakiot (pienimmästä suurimpaan) <code>UNSENT</code>, <code>OPENED</code>, <code>HEADERS_RECEIVED</code>, <code>LOADING</code> sekä <code>DONE</code> joihin päästään käsiksi <code>this</code>:n kautta. Jos attribuutin <code>readyState</code> arvo ei ole neljä (<code>DONE</code>), odotamme lopullista vastausta. Attribuutti <code>status</code> kertoo HTTP-pyynnön statuskoodin. Statuskoodi 200 kertoo pyynnön onnistuneen. Lisää tietoa statuskoodeista löytyy esimerkiksi googlella ja <a href="http://httpstatuscats.com/" target="_blank">täältä</a>.</p>
 
     <p>Ylläolevassa esimerkiksi vastaus näytetään <code>console.log</code>-komennon avulla. Käytännössä JSON-dataa sisältävän vastauksen voisi muuttaa <code>JSON.parse</code>-funktiolla olioksi.</p>
 


### PR DESCRIPTION
Multiple small changes to XMLHttpRequest sections:
1. Replace magic numbers with contants ( `4` --> `this.DONE`)
2. Remove empty string arguments for `send()` on `GET` requests.
3. Do not set `Content-Length` and `Connection`. The [XMLHttpRequest working draft](http://www.w3.org/TR/XMLHttpRequest/#the-setrequestheader%28%29-method) disallows this and some browsers (f.ex. Chrome) whine about trying to set them. 
   
   Besides, the method used in the examples is flawed: If the content contains multibyte utf characters, the resulting content-length is too short.
4. Remove explicitly settings XMLHttpRequest to use asynchronous mode. The boolean parameter defaults to true (asynchronous).
