### PR TITLE
Syntax error korjattu Grunt-esimerkkikoodista

### DIFF
--- a/index.html
+++ b/index.html
@@ -8017,7 +8017,7 @@ module.exports = function(grunt) {
         src: ['app/app.js', 'app/services/*.js', 'app/controllers/*.js'],
         dest: 'app/app.min.js'
       }
-    }
+    },
     jshint: {
       src: ['app/**/**.js']
     }


### PR DESCRIPTION
Uglifyn ja Jshintin confien välistä puuttui pilkku.
